### PR TITLE
Improve update API by removing double optionals

### DIFF
--- a/Sources/Persist/Persister.swift
+++ b/Sources/Persist/Persister.swift
@@ -3,6 +3,8 @@ import Foundation
 import Combine
 #endif
 
+extension Persister.Update.Event: Hashable where Value: Hashable {}
+extension Persister.Update.Event: Equatable where Value: Equatable {}
 extension Persister.Update: Hashable where Value: Hashable {}
 extension Persister.Update: Equatable where Value: Equatable {}
 
@@ -12,21 +14,47 @@ extension Persister.Update: Equatable where Value: Equatable {}
  */
 public final class Persister<Value> {
     /// An update that was performed by a persister.
-    public enum Update {
-        /// The was persisted.
-        case persisted(Value)
+    public struct Update {
+        public static func persisted(_ persistedValue: Value) -> Update {
+            return Update(newValue: persistedValue, event: .persisted(persistedValue))
+        }
 
-        /// The value was removed.
-        case removed
+        public static func removed(defaultValue: Value) -> Update {
+            return Update(newValue: defaultValue, event: .removed)
+        }
 
-        /// The value after the update. `nil` indicates the value was removed.
-        public var value: Value? {
-            switch self {
-            case .persisted(let value):
-                return value
-            case .removed:
-                return nil
+        public enum Event {
+            /// The was persisted.
+            case persisted(Value)
+
+            /// The value was removed.
+            case removed
+
+            /// The value after the update. `nil` indicates the value was removed.
+            public var value: Value? {
+                switch self {
+                case .persisted(let value):
+                    return value
+                case .removed:
+                    return nil
+                }
             }
+        }
+
+        /// The new value, after the update. If the value was removed this will be the default value.
+        public let newValue: Value
+
+        @available(*, deprecated, renamed: "newValue")
+        public var value: Value {
+            return newValue
+        }
+
+        /// The event that triggered the update.
+        public let event: Event
+
+        private init(newValue: Value, event: Event) {
+            self.newValue = newValue
+            self.event = event
         }
     }
 
@@ -164,7 +192,7 @@ public final class Persister<Value> {
             addUpdateListener: { updateListener in
                 return storage.addUpdateListener(forKey: key) { newValue in
                     guard let value = newValue else {
-                        updateListener(.success(.removed))
+                        updateListener(.success(.removed(defaultValue: defaultValue)))
                         return
                     }
 
@@ -214,7 +242,7 @@ public final class Persister<Value> {
             addUpdateListener: { updateListener in
                 return storage.addUpdateListener(forKey: key) { newValue in
                     guard let value = newValue else {
-                        updateListener(.success(.removed))
+                        updateListener(.success(.removed(defaultValue: defaultValue)))
                         return
                     }
 
@@ -264,7 +292,7 @@ public final class Persister<Value> {
             addUpdateListener: { updateListener in
                 return storage.addUpdateListener(forKey: key) { newValue in
                     guard let anyValue = newValue else {
-                        updateListener(.success(.removed))
+                        updateListener(.success(.removed(defaultValue: defaultValue)))
                         return
                     }
 
@@ -322,7 +350,7 @@ public final class Persister<Value> {
             addUpdateListener: { updateListener in
                 return storage.addUpdateListener(forKey: key) { newValue in
                     guard let anyValue = newValue else {
-                        updateListener(.success(.removed))
+                        updateListener(.success(.removed(defaultValue: defaultValue)))
                         return
                     }
 
@@ -382,7 +410,7 @@ public final class Persister<Value> {
             addUpdateListener: { updateListener in
                 return storage.addUpdateListener(forKey: key) { newValue in
                     guard let anyValue = newValue else {
-                        updateListener(.success(.removed))
+                        updateListener(.success(.removed(defaultValue: defaultValue)))
                         return
                     }
 
@@ -450,7 +478,7 @@ public final class Persister<Value> {
             addUpdateListener: { updateListener in
                 return storage.addUpdateListener(forKey: key) { newValue in
                     guard let anyValue = newValue else {
-                        updateListener(.success(.removed))
+                        updateListener(.success(.removed(defaultValue: defaultValue)))
                         return
                     }
 
@@ -514,7 +542,7 @@ public final class Persister<Value> {
             addUpdateListener: { updateListener in
                 return storage.addUpdateListener(forKey: key) { newValue in
                     guard let newValue = newValue else {
-                        updateListener(.success(.removed))
+                        updateListener(.success(.removed(defaultValue: defaultValue)))
                         return
                     }
 
@@ -576,7 +604,7 @@ public final class Persister<Value> {
             addUpdateListener: { updateListener in
                 return storage.addUpdateListener(forKey: key) { newValue in
                     guard let newValue = newValue else {
-                        updateListener(.success(.removed))
+                        updateListener(.success(.removed(defaultValue: defaultValue)))
                         return
                     }
 

--- a/Tests/PersistTests/FileManagerStorageTests.swift
+++ b/Tests/PersistTests/FileManagerStorageTests.swift
@@ -106,7 +106,7 @@ final class FileManagerStorageTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(update.value, writtenData, "Value passed to update listener should be new data when file has been updated on disk")
+                XCTAssertEqual(update.newValue, writtenData, "Value passed to update listener should be new data when file has been updated on disk")
             case .failure(let error):
                 XCTFail("Update listener should be notified of a success. Got error: \(error)")
             }
@@ -138,8 +138,8 @@ final class FileManagerStorageTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(update.value, .none)
-                XCTAssertEqual(update, .removed, "Value passed to update listener should be `.removed` when file has been deleted on disk")
+                XCTAssertEqual(update.newValue, .none)
+                XCTAssertEqual(update.event, .removed, "Value passed to update listener should be `.removed` when file has been deleted on disk")
             case .failure(let error):
                 XCTFail("Update listener should be notified of a success. Got error: \(error)")
             }

--- a/Tests/PersistTests/NSUbiquitousKeyValueStoreStorageTests.swift
+++ b/Tests/PersistTests/NSUbiquitousKeyValueStoreStorageTests.swift
@@ -383,7 +383,7 @@ final class NSUbiquitousKeyValueStoreStorageTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(update.value, setValue)
+                XCTAssertEqual(update.newValue, setValue)
             case .failure(let error):
                 XCTFail("Should return a success for updated values, not \(error)")
             }
@@ -400,7 +400,7 @@ final class NSUbiquitousKeyValueStoreStorageTests: XCTestCase {
 
                 switch result {
                 case .success(let update):
-                    XCTAssertEqual(update.value, setValue)
+                    XCTAssertEqual(update.newValue, setValue)
                 case .failure:
                     XCTFail("Should return a success for updated values")
                 }

--- a/Tests/PersistTests/PersistedTests.swift
+++ b/Tests/PersistTests/PersistedTests.swift
@@ -40,7 +40,7 @@ final class PersistedTests: XCTestCase {
                 if callCount == 0 {
                     XCTAssertEqual(update, .persisted(newValue), "Update listener should receive `persisted` update with new value")
                 } else if callCount == 1 {
-                    XCTAssertEqual(update, .removed, "Update listener should receive `removed` update")
+                    XCTAssertEqual(update.event, .removed, "Update listener should receive `removed` update")
                 }
             case .failure:
                 XCTFail("Update should not fail")
@@ -96,7 +96,7 @@ final class PersistedTests: XCTestCase {
                 if callCount % 2 == 0 {
                     XCTAssertEqual(update, .persisted(newValue), "Update listener should receive `persisted` update with new value")
                 } else {
-                    XCTAssertEqual(update, .removed, "Update listener should receive `removed` update")
+                    XCTAssertEqual(update.event, .removed, "Update listener should receive `removed` update")
                 }
             case .failure:
                 XCTFail("Update should not fail")
@@ -160,7 +160,7 @@ final class PersistedTests: XCTestCase {
                 if callCount == 0 {
                     XCTAssertEqual(update, .persisted(newValue), "Update listener should receive `persisted` update with new value")
                 } else if callCount == 1 {
-                    XCTAssertEqual(update, .removed, "Update listener should receive `removed` update")
+                    XCTAssertEqual(update.event, .removed, "Update listener should receive `removed` update")
                 }
             case .failure:
                 XCTFail("Update should not fail")
@@ -216,7 +216,7 @@ final class PersistedTests: XCTestCase {
                 if callCount % 2 == 0 {
                     XCTAssertEqual(update, .persisted(newValue), "Update listener should receive `persisted` update with new value")
                 } else {
-                    XCTAssertEqual(update, .removed, "Update listener should receive `removed` update")
+                    XCTAssertEqual(update.event, .removed, "Update listener should receive `removed` update")
                 }
             case .failure:
                 XCTFail("Update should not fail")
@@ -358,7 +358,7 @@ final class PersistedTests: XCTestCase {
                 if callCount == 0 {
                     XCTAssertEqual(update, .persisted(newValue), "Update listener should receive `persisted` update with new value")
                 } else if callCount == 1 {
-                    XCTAssertEqual(update, .removed, "Update listener should receive `removed` update")
+                    XCTAssertEqual(update.event, .removed, "Update listener should receive `removed` update")
                 }
             case .failure:
                 XCTFail("Update should not fail")
@@ -563,7 +563,7 @@ final class PersistedTests: XCTestCase {
                 if callCount % 2 == 0 {
                     XCTAssertEqual(update, .persisted("new-value"), "Update listener should receive `persisted` update with new value")
                 } else  {
-                    XCTAssertEqual(update, .removed, "Update listener should receive `removed` update")
+                    XCTAssertEqual(update.event, .removed, "Update listener should receive `removed` update")
                 }
             case .failure:
                 XCTFail("Update should not fail")
@@ -630,7 +630,7 @@ final class PersistedTests: XCTestCase {
                 if callCount == 0 {
                     XCTAssertEqual(update, .persisted(newValue), "Update listener should receive `persisted` update with new value")
                 } else if callCount == 1 {
-                    XCTAssertEqual(update, .removed, "Update listener should receive `removed` update")
+                    XCTAssertEqual(update.event, .removed, "Update listener should receive `removed` update")
                 }
             case .failure:
                 XCTFail("Update should not fail")
@@ -721,7 +721,7 @@ final class PersistedTests: XCTestCase {
                 if callCount % 2 == 0 {
                     XCTAssertEqual(update, .persisted(newValue), "Update listener should receive `persisted` update with new value")
                 } else {
-                    XCTAssertEqual(update, .removed, "Update listener should receive `removed` update")
+                    XCTAssertEqual(update.event, .removed, "Update listener should receive `removed` update")
                 }
             case .failure:
                 XCTFail("Update should not fail")

--- a/Tests/PersistTests/PersisterTests.swift
+++ b/Tests/PersistTests/PersisterTests.swift
@@ -21,7 +21,7 @@ final class PersisterTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(update.value, storedValue, "Value passed to update listener should be the new, untransformed, value")
+                XCTAssertEqual(update.newValue, storedValue, "Value passed to update listener should be the new, untransformed, value")
             case .failure(let error):
                 XCTFail("Update listener should be notified of a success. Got error: \(error)")
             }
@@ -49,7 +49,7 @@ final class PersisterTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(update.value, storedValue, "Value passed to update listener should be the new, untransformed, value")
+                XCTAssertEqual(update.newValue, storedValue, "Value passed to update listener should be the new, untransformed, value")
             case .failure(let error):
                 XCTFail("Update listener should be notified of a success. Got error: \(error)")
             }
@@ -80,7 +80,7 @@ final class PersisterTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(update.value, storedValue, "Value passed to update listener should be the new, untransformed, value")
+                XCTAssertEqual(update.newValue, storedValue, "Value passed to update listener should be the new, untransformed, value")
             case .failure(let error):
                 XCTFail("Update listener should be notified of a success. Got error: \(error)")
             }

--- a/Tests/PersistTests/PropertyListTransformerTests.swift
+++ b/Tests/PersistTests/PropertyListTransformerTests.swift
@@ -51,7 +51,7 @@ final class PropertyListTransformerTests: XCTestCase {
 
             switch result {
             case .success(let update):
-                XCTAssertEqual(update.value, storedValue, "Value passed to update listener should be the new value")
+                XCTAssertEqual(update.newValue, storedValue, "Value passed to update listener should be the new value")
             case .failure(let error):
                 XCTFail("Update listener should be notified of a success. Got error: \(error)")
             }


### PR DESCRIPTION
The `Update` will now contain the value after the update, not just the value change that triggered the update. Closes #11.