### PR TITLE
Add `Hashable` requirement to `Cancellable`

### DIFF
--- a/Sources/Persist/AnyCancellable.swift
+++ b/Sources/Persist/AnyCancellable.swift
@@ -1,0 +1,51 @@
+/// A concrete implementation of the `Cancellable` protocol.
+public final class AnyCancellable: Cancellable {
+    public static func == (lhs: AnyCancellable, rhs: AnyCancellable) -> Bool {
+        lhs._isEqual(rhs)
+    }
+
+    private let _isEqual: (_ rhs: AnyCancellable) -> Bool
+
+    private let _cancel: () -> Void
+
+    private let _hash: (_ hasher: inout Hasher) -> Void
+
+    private let cancellable: Any
+
+    /// Initialise a new `AnyCancellable` that wraps the provided cancellable.
+    ///
+    /// This object will **not** call `cancel` when deinitialised to allow the wrapped `Cancellable`
+    /// to be stored independently of the wrapper.
+    ///
+    /// - Parameter cancellable: The `Cancellable` to wrap.
+    public init<Cancellable: Persist.Cancellable>(_ cancellable: Cancellable) {
+        _isEqual = { rhs in
+            guard let rhsCancellable = rhs.cancellable as? Cancellable else { return false }
+            return cancellable == rhsCancellable
+        }
+        _cancel = {
+            cancellable.cancel()
+        }
+        _hash = { hasher in
+            cancellable.hash(into: &hasher)
+        }
+        self.cancellable = cancellable
+    }
+
+    public func cancel() {
+        _cancel()
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        _hash(&hasher)
+    }
+}
+
+extension Cancellable {
+    /// Initialise any return a new `AnyCancellable` that wraps this `Cancellable` instance.
+    ///
+    /// - Returns: The `AnyCancellable` that wraps this `Canellable`.
+    public func eraseToAnyCancellable() -> AnyCancellable {
+        return AnyCancellable(self)
+    }
+}

--- a/Sources/Persist/Cancellable.swift
+++ b/Sources/Persist/Cancellable.swift
@@ -3,7 +3,7 @@
 
  Implementations of this protocol must call the `cancel` function on `deinit`.
  */
-public protocol Cancellable: class {
+public protocol Cancellable: class, Hashable {
     /**
      Stop further updates being sent to the update listener, freeing any resources held on to by the
      subscription.

--- a/Sources/Persist/FileManager/FileManagerStorage.swift
+++ b/Sources/Persist/FileManager/FileManagerStorage.swift
@@ -67,7 +67,7 @@ public final class FileManagerStorage: Storage {
      - parameter updateListener: The closure to call when the file changes.
      - returns: An object that represents the subscription and can be used to cancel further updates.
      */
-    public func addUpdateListener(forKey url: URL, updateListener: @escaping UpdateListener) -> Cancellable {
+    public func addUpdateListener(forKey url: URL, updateListener: @escaping UpdateListener) -> Subscription {
         let uuid = UUID()
 
         updateListeners[url, default: [:]][uuid] = updateListener

--- a/Sources/Persist/InMemoryStorage.swift
+++ b/Sources/Persist/InMemoryStorage.swift
@@ -56,7 +56,7 @@ open class InMemoryStorage<StoredValue>: Storage {
      - parameter updateListener: The closure to call when an update occurs.
      - returns: An object that represents the closure's subscription to changes. This object must be retained by the caller.
      */
-    open func addUpdateListener(forKey key: String, updateListener: @escaping UpdateListener) -> Cancellable {
+    open func addUpdateListener(forKey key: String, updateListener: @escaping UpdateListener) -> Subscription {
         let uuid = UUID()
 
         updateListeners[key, default: [:]][uuid] = updateListener

--- a/Sources/Persist/NSUbiquitousKeyValueStore/NSUbiquitousKeyValueStoreStorage.swift
+++ b/Sources/Persist/NSUbiquitousKeyValueStore/NSUbiquitousKeyValueStoreStorage.swift
@@ -72,7 +72,7 @@ public final class NSUbiquitousKeyValueStoreStorage: Storage {
      - parameter updateListener: The closure to call when an update occurs.
      - returns: An object that represents the closure's subscription to changes. This object must be retained by the caller.
      */
-    public func addUpdateListener(forKey key: String, updateListener: @escaping UpdateListener) -> Cancellable {
+    public func addUpdateListener(forKey key: String, updateListener: @escaping UpdateListener) -> Subscription {
         return addUpdateListener(forKey: key, notificationCenter: .default, updateListener: updateListener)
     }
 
@@ -84,7 +84,7 @@ public final class NSUbiquitousKeyValueStoreStorage: Storage {
      - parameter updateListener: The closure to call when an update occurs.
      - returns: An object that represents the closure's subscription to changes. This object must be retained by the caller.
     */
-    public func addUpdateListener(forKey key: String, notificationCenter: NotificationCenter, updateListener: @escaping UpdateListener) -> Cancellable {
+    public func addUpdateListener(forKey key: String, notificationCenter: NotificationCenter, updateListener: @escaping UpdateListener) -> Subscription {
         let notificationObserver = notificationCenter.addObserver(
             forName: NSUbiquitousKeyValueStore.didChangeExternallyNotification,
             object: nsUbiquitousKeyValueStore,

--- a/Sources/Persist/Persister.swift
+++ b/Sources/Persist/Persister.swift
@@ -74,7 +74,7 @@ public final class Persister<Value> {
     public typealias ValueRemover = () throws -> Void
 
     /// A closure that can add an update listener.
-    public typealias AddUpdateListener = (@escaping UpdateListener) -> Cancellable
+    public typealias AddUpdateListener = (@escaping UpdateListener) -> Subscription
 
     #if canImport(Combine)
     /// A publisher that will publish updates as they occur.
@@ -102,7 +102,7 @@ public final class Persister<Value> {
     private let valueRemover: ValueRemover
 
     /// The cancellable object that encapsulates updates from the storage.
-    private var storageUpdateListenerCancellable: Cancellable?
+    private var storageUpdateListenerCancellable: Subscription?
 
     /// A collection of the update listeners that will be notified when a value changes. The key (a `UUID`)
     /// is not exposed, but rather captured by the `Subscription` that the caller retains.
@@ -693,7 +693,7 @@ public final class Persister<Value> {
      - parameter updateListener: The closure to call when an update occurs.
      - returns: An object that represents the closure's subscription to changes. This object must be retained by the caller.
      */
-    public func addUpdateListener(_ updateListener: @escaping UpdateListener) -> Cancellable {
+    public func addUpdateListener(_ updateListener: @escaping UpdateListener) -> Subscription {
         let uuid = UUID()
         updateListeners[uuid] = updateListener
 

--- a/Sources/Persist/Storage.swift
+++ b/Sources/Persist/Storage.swift
@@ -43,5 +43,5 @@ public protocol Storage: class {
      - parameter updateListener: A closure to call when an update occurs.
      - returns: An object that represents the closure's subscription to changes. This object must be retained by the caller.
      */
-    func addUpdateListener(forKey key: Key, updateListener: @escaping UpdateListener) -> Cancellable
+    func addUpdateListener(forKey key: Key, updateListener: @escaping UpdateListener) -> Subscription
 }

--- a/Sources/Persist/Subscription.swift
+++ b/Sources/Persist/Subscription.swift
@@ -1,7 +1,10 @@
 /**
  An object that represents a subscription to a `Storage` update.
  */
-public final class Subscription: Cancellable {
+open class Subscription: Cancellable {
+    public static func == (lhs: Subscription, rhs: Subscription) -> Bool {
+        return ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+    }
 
     /// A closure that will be called when the subscription is cancelled.
     public typealias CancelClosure = () -> Void
@@ -25,10 +28,13 @@ public final class Subscription: Cancellable {
      Cancel the update subscription, preventing further updates being sent to the update listener, freeing any
      resources held on to by the subscription.
      */
-    public func cancel() {
+    open func cancel() {
         guard let cancelClosure = cancelClosure else { return }
         cancelClosure()
         self.cancelClosure = nil
     }
 
+    open func hash(into hasher: inout Hasher) {
+        ObjectIdentifier(self).hash(into: &hasher)
+    }
 }

--- a/Sources/Persist/UserDefaults/UserDefaultsStorage.swift
+++ b/Sources/Persist/UserDefaults/UserDefaultsStorage.swift
@@ -91,7 +91,7 @@ public final class UserDefaultsStorage: Storage {
      - parameter updateListener: The closure to call when an update occurs.
      - returns: An object that represents the closure's subscription to changes. This object must be retained by the caller.
      */
-    public func addUpdateListener(forKey key: String, updateListener: @escaping UpdateListener) -> Cancellable {
+    public func addUpdateListener(forKey key: String, updateListener: @escaping UpdateListener) -> Subscription {
         let observer = KeyPathObserver(updateListener: updateListener)
         userDefaults.addObserver(observer, forKeyPath: key, options: .new, context: nil)
         let subscription = Subscription { [weak userDefaults] in

--- a/Tests/PersistTests/AnyCancellableTests.swift
+++ b/Tests/PersistTests/AnyCancellableTests.swift
@@ -1,0 +1,77 @@
+#if !os(watchOS)
+import Persist
+import XCTest
+
+final class AnyCancellableTests: XCTestCase {
+
+    func testEqualsFunctionWithSameWrappedTypeCallsWrappedEquals() {
+        let wrapped = MockCancellable()
+        let wrapped2 = MockCancellable()
+        let anyCancellable = wrapped.eraseToAnyCancellable()
+        let anyCancellable2 = wrapped2.eraseToAnyCancellable()
+
+        _ = anyCancellable == anyCancellable2
+
+        XCTAssertEqual(wrapped.equalsCallCount, 1, "Must call == once")
+        XCTAssertEqual(wrapped2.equalsCallCount, 1, "Must call == once")
+    }
+
+    func testEqualsFunctionWithDifferentWrappedTypeDoesNotCallWrappedEquals() {
+        let wrapped = MockCancellable()
+        let wrapped2 = Subscription(cancel: {})
+        let anyCancellable = wrapped.eraseToAnyCancellable()
+        let anyCancellable2 = wrapped2.eraseToAnyCancellable()
+
+        _ = anyCancellable == anyCancellable2
+
+        XCTAssertEqual(wrapped.equalsCallCount, 0, "Must not call ==")
+    }
+
+    func testCancelFunctionCallsWrappedCancel() {
+        let wrapped = MockCancellable()
+        let anyCancellable = wrapped.eraseToAnyCancellable()
+        anyCancellable.cancel()
+
+        XCTAssertEqual(wrapped.cancelCallCount, 1, "Must call cancel once")
+    }
+
+    func testHashFunctionCallsWrappedHash() {
+        let wrapped = MockCancellable()
+        let anyCancellable = wrapped.eraseToAnyCancellable()
+        _ = anyCancellable.hashValue
+
+        XCTAssertEqual(wrapped.hashCallCount, 1, "Must call cancel once")
+    }
+
+    func testDeinitDoesNotCallWrappedCancel() {
+        let wrapped = MockCancellable()
+        var anyCancellable: AnyCancellable? = wrapped.eraseToAnyCancellable()
+        _ = anyCancellable
+        anyCancellable = nil
+
+        XCTAssertEqual(wrapped.cancelCallCount, 0, "Must not call cancel")
+    }
+
+}
+
+private final class MockCancellable: Cancellable {
+    static func == (lhs: MockCancellable, rhs: MockCancellable) -> Bool {
+        lhs.equalsCallCount += 1
+        rhs.equalsCallCount += 1
+        return lhs === rhs
+    }
+
+    private(set) var equalsCallCount = 0
+    private(set) var cancelCallCount = 0
+    private(set) var hashCallCount = 0
+
+    func cancel() {
+        cancelCallCount += 1
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hashCallCount += 1
+        ObjectIdentifier(self).hash(into: &hasher)
+    }
+}
+#endif

--- a/Tests/PersistTests/SubscriptionTests.swift
+++ b/Tests/PersistTests/SubscriptionTests.swift
@@ -1,0 +1,52 @@
+#if !os(watchOS)
+import Persist
+import XCTest
+
+final class SubscriptionTests: XCTestCase {
+
+    func testDeinitDoesNotCallCancelClosureWhenCancelHasBeenCalled() {
+        var cancelCallCount = 0
+
+        do {
+            let subscription = Subscription(cancel: { cancelCallCount += 1 })
+            subscription.cancel()
+        }
+
+        XCTAssertEqual(cancelCallCount, 1, "Must call closure once")
+    }
+
+    func testDeinitDoesNotCallCancelClosureForSubsequentCancelCalls() {
+        var cancelCallCount = 0
+        let subscription = Subscription(cancel: { cancelCallCount += 1 })
+        subscription.cancel()
+
+        XCTAssertEqual(cancelCallCount, 1, "Must call closure once")
+    }
+
+    func testDeinitCallsCancelClosure() {
+        var cancelCallCount = 0
+
+        do {
+            _ = Subscription(cancel: { cancelCallCount += 1 })
+        }
+
+        XCTAssertEqual(cancelCallCount, 1, "Must call closure once")
+    }
+
+    func testEquality() {
+        let subscription1 = Subscription(cancel: {})
+        let subscription2 = Subscription(cancel: {})
+
+        XCTAssertEqual(subscription1, subscription1, "Subscription must be equal to self")
+        XCTAssertNotEqual(subscription1, subscription2, "Subscription must not be equal to other instance")
+    }
+
+    func testHashValue() {
+        let subscription1 = Subscription(cancel: {})
+        let subscription2 = Subscription(cancel: {})
+
+        XCTAssertNotEqual(subscription1.hashValue, subscription2.hashValue, "Subscription hash value must not be equal to other instance")
+    }
+
+}
+#endif


### PR DESCRIPTION
Functions that return `Cancellable` have been updated to return `Subscription`.

`AnyCancellable` has been added to allow for type erasure.