### PR TITLE
Add OSLog support without poisoning namespace

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,9 +8,11 @@ let package = Package(
     ],
     products: [
         .library(name: "Persist", targets: ["Persist"]),
+        .library(name: "PersistLogger", targets: ["PersistLogger"]),
     ],
     targets: [
-        .target(name: "Persist"),
+        .target(name: "Persist", dependencies: ["PersistLogger"]),
         .testTarget(name: "PersistTests", dependencies: ["Persist"]),
+        .target(name: "PersistLogger"),
     ]
 )

--- a/Package@swift-5.3.swift
+++ b/Package@swift-5.3.swift
@@ -8,9 +8,11 @@ let package = Package(
     ],
     products: [
         .library(name: "Persist", targets: ["Persist"]),
+        .library(name: "PersistLogger", targets: ["PersistLogger"]),
     ],
     targets: [
-        .target(name: "Persist"),
+        .target(name: "Persist", dependencies: ["PersistLogger"]),
         .testTarget(name: "PersistTests", dependencies: ["Persist"]),
+        .target(name: "PersistLogger"),
     ]
 )

--- a/Sources/Persist/Persister+OSLog.swift
+++ b/Sources/Persist/Persister+OSLog.swift
@@ -1,0 +1,30 @@
+#if canImport(os)
+import os.log
+import PersistLogger
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+extension Persister {
+    /**
+     Create a new `Persister` instance.
+
+     - parameter valueGetter: The closure that will be called when the `retrieveValue()` function is called.
+     - parameter valueSetter: The closure that will be called when the `persist(_:)` function is called.
+     - parameter valueRemover: The closure that will be called when the `removeValue()` function is called.
+     - parameter defaultValue: The value to use when a value has not yet been stored, or an error occurs. This value is lazily evaluated.
+     - parameter defaultValuePersistBehaviour: An option set that describes when to persist the default value. Defaults to `[]`.
+     - parameter addUpdateListener: A closure that will be called immediately to add an update listener.
+     */
+    public convenience init(
+        valueGetter: @escaping ValueGetter,
+        valueSetter: @escaping ValueSetter,
+        valueRemover: @escaping ValueRemover,
+        defaultValue: @autoclosure @escaping () -> Value,
+        defaultValuePersistBehaviour: DefaultValuePersistOption = [],
+        osLog: OSLog,
+        addUpdateListener: AddUpdateListener
+    ) {
+        let logger = OSLogPersistLogger(log: osLog)
+        self.init(valueGetter: valueGetter, valueSetter: valueSetter, valueRemover: valueRemover, defaultValue: defaultValue(), defaultValuePersistBehaviour: defaultValuePersistBehaviour, logger: logger, addUpdateListener: addUpdateListener)
+    }
+}
+#endif

--- a/Sources/Persist/Persister.swift
+++ b/Sources/Persist/Persister.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PersistLogger
 #if canImport(Combine)
 import Combine
 #endif
@@ -155,6 +156,7 @@ public final class Persister<Value> {
         valueRemover: @escaping ValueRemover,
         defaultValue: @autoclosure @escaping () -> Value,
         defaultValuePersistBehaviour: DefaultValuePersistOption = [],
+        logger: PersistLogger? = nil,
         addUpdateListener: AddUpdateListener
     ) {
         self.valueGetter = valueGetter

--- a/Sources/PersistLogger/OSLogPersistLogger.swift
+++ b/Sources/PersistLogger/OSLogPersistLogger.swift
@@ -1,0 +1,98 @@
+#if canImport(os)
+import Foundation
+import os.log
+
+@available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *)
+open class OSLogPersistLogger: PersistLogger {
+
+    open var log: OSLog
+
+    public init(log: OSLog) {
+        self.log = log
+    }
+
+    /**
+     Log a message capturing information about things that might result in a failure.
+
+     The system's default behavior is to store the default messages in memory buffers. When the
+     memory buffers are full, the system compresses those buffers and moves them to the data store.
+     They remain there until a storage quota is exceeded, at which point the system purges the
+     oldest messages.
+     */
+    public func `default`(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .default, args: args)
+    }
+
+    /**
+     Log a message capturing information that may be helpful, but isn’t essential, for
+     troubleshooting errors.
+
+     The system's default behavior is to store info messages in memory buffers. The system purges
+     these messages when the memory buffers are full.
+
+     When a piece of code logs an error or fault message, the info messages are also copied to the
+     data store. They remain there until a storage quota is exceeded, at which point the system
+     purges the oldest messages.
+     */
+    public func info(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .info, args: args)
+    }
+
+    /**
+     Use this level to capture verbose information that may be useful during development or while
+     troubleshooting a specific problem. Debug logging is intended for use in a development
+     environment and not in shipping software.
+
+     The system's default behavior is to discard debug messages; it only captures them when you
+     enable debug logging using the tools or a custom configuration.
+     */
+    public func debug(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .debug, args: args)
+    }
+
+    /**
+     Use this level to capture information about process-level errors.
+
+     The system always saves error messages in the data store. They remain there until a storage
+     quota is exceeded, at which point the system purges the oldest messages.
+
+     When you log an error message, the system saves other messages to the data store. If an
+     activity object exists, the system captures information for the entire process chain related to
+     that activity.
+     */
+    public func error(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .error, args: args)
+    }
+
+    /**
+     Use this level only when you want to capture information about system-level or multi-process
+     errors.
+
+     The system always saves fault messages in the data store. They remain there until a storage
+     quota is exceeded, at which point, the oldest messages are purged.
+
+     When you log an fault message, the system saves other messages to the data store. If an
+     activity object exists, the system captures information for the entire process chain related to
+     that activity.
+     */
+    public func fault(_ message: StaticString, _ args: CVarArg...) {
+        log(message, type: .fault, args: args)
+    }
+
+    private func log(_ message: StaticString, type: OSLogType, args: [CVarArg]) {
+        switch args.count {
+        case 0:
+            os_log(message, log: log, type: type)
+        case 1:
+            os_log(message, log: log, type: type, args[0])
+        case 2:
+            os_log(message, log: log, type: type, args[0], args[1])
+        case 3:
+            os_log(message, log: log, type: type, args[0], args[1], args[2])
+        default:
+            assertionFailure("Too many arguments passed to log. Update this to support this many arguments.")
+            os_log(message, log: log, type: type, args[0], args[1], args[2])
+        }
+    }
+}
+#endif

--- a/Sources/PersistLogger/PersistLogger.swift
+++ b/Sources/PersistLogger/PersistLogger.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+public protocol PersistLogger {
+    /**
+     Log a message capturing information about things that might result in a failure.
+
+     The system's default behavior is to store the default messages in memory buffers. When the
+     memory buffers are full, the system compresses those buffers and moves them to the data store.
+     They remain there until a storage quota is exceeded, at which point the system purges the
+     oldest messages.
+     */
+    func `default`(_ message: StaticString, _ args: CVarArg...)
+
+    /**
+     Log a message capturing information that may be helpful, but isn’t essential, for
+     troubleshooting errors.
+
+     The system's default behavior is to store info messages in memory buffers. The system purges
+     these messages when the memory buffers are full.
+
+     When a piece of code logs an error or fault message, the info messages are also copied to the
+     data store. They remain there until a storage quota is exceeded, at which point the system
+     purges the oldest messages.
+     */
+    func info(_ message: StaticString, _ args: CVarArg...)
+
+    /**
+     Use this level to capture verbose information that may be useful during development or while
+     troubleshooting a specific problem. Debug logging is intended for use in a development
+     environment and not in shipping software.
+
+     The system's default behavior is to discard debug messages; it only captures them when you
+     enable debug logging using the tools or a custom configuration.
+     */
+    func debug(_ message: StaticString, _ args: CVarArg...)
+
+    /**
+     Use this level to capture information about process-level errors.
+
+     The system always saves error messages in the data store. They remain there until a storage
+     quota is exceeded, at which point the system purges the oldest messages.
+
+     When you log an error message, the system saves other messages to the data store. If an
+     activity object exists, the system captures information for the entire process chain related to
+     that activity.
+     */
+    func error(_ message: StaticString, _ args: CVarArg...)
+
+    /**
+     Use this level only when you want to capture information about system-level or multi-process
+     errors.
+
+     The system always saves fault messages in the data store. They remain there until a storage
+     quota is exceeded, at which point, the oldest messages are purged.
+
+     When you log an fault message, the system saves other messages to the data store. If an
+     activity object exists, the system captures information for the entire process chain related to
+     that activity.
+     */
+    func fault(_ message: StaticString, _ args: CVarArg...)
+}

--- a/Tests/PersistTests/PersisterTests.swift
+++ b/Tests/PersistTests/PersisterTests.swift
@@ -5,6 +5,18 @@ import XCTest
 final class PersisterTests: XCTestCase {
 
     func testStoringValueWithAnyStorageType() throws {
+        if #available(macOS 10.12, iOS 10.0, watchOS 3.0, tvOS 10.0, *) {
+            _ = Persister<String>(
+                valueGetter: { "foo" },
+                valueSetter: { _ in },
+                valueRemover: { },
+                defaultValue: "",
+                defaultValuePersistBehaviour: .all,
+                osLog: .disabled,
+                addUpdateListener: { _, _ in return Subscription(cancel: {}).eraseToAnyCancellable() }
+            )
+        }
+
         struct StoredValue: Codable, Equatable {
             let property: String
         }


### PR DESCRIPTION
This is an attempt to add support for OSLog without increasing the minimum platform requirements.

The use of a separate target means that the extra types required should not interfere with consumers.

The main question is whether `#if canImport(os)` will resolve to `false` on linux. If not then it may fail to compile and a platform check could be required.