### PR TITLE
Replace uses of protocol `class` with `AnyObject`

### DIFF
--- a/Sources/Persist/Cancellable.swift
+++ b/Sources/Persist/Cancellable.swift
@@ -3,7 +3,7 @@
 
  Implementations of this protocol must call the `cancel` function on `deinit`.
  */
-public protocol Cancellable: class, Hashable {
+public protocol Cancellable: AnyObject, Hashable {
     /**
      Stop further updates being sent to the update listener, freeing any resources held on to by the
      subscription.

--- a/Sources/Persist/Storage.swift
+++ b/Sources/Persist/Storage.swift
@@ -1,7 +1,7 @@
 /**
  A protocol that defines the interface to store, remove, and retrieve values by a string key.
  */
-public protocol Storage: class {
+public protocol Storage: AnyObject {
 
     /// The type of the keys used to reference values in the storage.
     associatedtype Key


### PR DESCRIPTION
`class` has been deprecated in Swift 5.4